### PR TITLE
Task: Remove the appeared question form the list;

### DIFF
--- a/prototype/Assets/Scripts/SanctumQuiz.cs
+++ b/prototype/Assets/Scripts/SanctumQuiz.cs
@@ -65,7 +65,14 @@ public class SanctumQuiz : MonoBehaviour
 
     public void correct()
     {
-        questionAnswers.RemoveAt(currQuestion);
+
+        if (currQuestion != questionAnswers.Count-1) {
+           QuizQA last = questionAnswers[questionAnswers.Count-1];
+           questionAnswers[currQuestion] = last;
+        } 
+        questionAnswers.RemoveAt(questionAnswers.Count-1);
+        
+
         Send(currQuestion, 1, 0);
         //gameOver();
         
@@ -164,6 +171,7 @@ public class SanctumQuiz : MonoBehaviour
         if(questionAnswers.Count > 0)
         {
             currQuestion = Random.Range(0, questionAnswers.Count);
+
 
             questionText.text = questionAnswers[currQuestion].question;
 


### PR DESCRIPTION
Update the remove algorithm.
The previous one takes O(n), and the new one takes  O(1) since we will have more questions later.

Problem found:
When the player is back to the main game after correctly answering the question, it actually starts a new main game instead of the previous main game status. Thus the question list will be initiated again for the next sanctum.

One possible solution, initialized the question list when a player is on the welcome board which enables the player won't encounter the same questions even at different levels.