### PR TITLE
Added logic for below functionalities

### DIFF
--- a/prototype/Assets/Scripts/CookingStation.cs
+++ b/prototype/Assets/Scripts/CookingStation.cs
@@ -6,6 +6,8 @@ using UnityEngine.SceneManagement;
 public class CookingStation : MonoBehaviour
 {
     PlayerMovement PlayerMovement;
+    public GameManager gameManager;
+    public bool i_set;
 
     private void OnTriggerEnter(Collider other)
     {
@@ -27,10 +29,30 @@ public class CookingStation : MonoBehaviour
         }
         else
         {
-            PlayerMovement.speed = 0;
-            PlayerMovement.horizontalMultiplier = 0;
-            PlayerMovement.jumpForce = 0;
-            SceneManager.LoadScene("Sanctum", LoadSceneMode.Additive);
+            if (gameObject.tag=="CookingStation")
+
+                    {
+                        
+                        
+                        if ( GroundSpawner.i_set ==false)
+                        {
+                        
+                        //Destroy(gameObject);
+                        return;
+                        
+
+                        }
+                        else
+                        {
+                            PlayerMovement.speed = 0;
+                            PlayerMovement.horizontalMultiplier = 0;
+                            PlayerMovement.jumpForce = 0;
+
+                            SceneManager.LoadScene("Sanctum", LoadSceneMode.Additive);
+
+                        }
+
+                    }    
         }
         
         Destroy(gameObject);

--- a/prototype/Assets/Scripts/GameManager.cs
+++ b/prototype/Assets/Scripts/GameManager.cs
@@ -135,21 +135,21 @@ public class GameManager : MonoBehaviour
         GameTracker.ingred1++;
         ingredient1 = GameTracker.ingred1;
         ingredient1Text.text = ": " + GameTracker.ingred1;
-        changeCoinAmount(-2);
+       // changeCoinAmount(-2);
     }
     public void IncrementIngredient2Count()
     {
         GameTracker.ingred2++;
         ingredient2 = GameTracker.ingred2;
         ingredient2Text.text = ": " + GameTracker.ingred2;
-        changeCoinAmount(-2);
+        //changeCoinAmount(-2);
     }
     public void IncrementIngredient3Count()
     {
         GameTracker.ingred3++;
         ingredient3 = GameTracker.ingred3;
         ingredient3Text.text = ": " + GameTracker.ingred3;
-        changeCoinAmount(-2);
+        //changeCoinAmount(-2);
     }
 
     // public void IncrementLemonCount() 
@@ -574,10 +574,10 @@ public class GameManager : MonoBehaviour
         // }
 
 
-        if (GameTracker.coins == 0 && (Math.Min(GameTracker.ingred1, Math.Min(GameTracker.ingred2, GameTracker.ingred3)) == 0))
-        {
-            gameOverScreen.Setup("You do not have enough balance of coins");
-        }
+        // if (GameTracker.coins == 0 && (Math.Min(GameTracker.ingred1, Math.Min(GameTracker.ingred2, GameTracker.ingred3)) == 0))
+        // {
+        //     gameOverScreen.Setup("You do not have enough balance of coins");
+        // }
 
         // poweruo sprites
         if (GameTracker.fiftyFiftyCount > 0)

--- a/prototype/Assets/Scripts/GroundSpawner.cs
+++ b/prototype/Assets/Scripts/GroundSpawner.cs
@@ -7,7 +7,7 @@ public class GroundSpawner : MonoBehaviour
     public GameObject groundTile;
     public GameObject terrainPrefab;
     public SanctumEntrance entrance;
-    
+    public static bool i_set;
     Vector3 nextSpawnPoint;
     public int hammerSpawnTime;
     int cnt = 0;
@@ -127,7 +127,7 @@ public class GroundSpawner : MonoBehaviour
                 }
                 
             }
-
+            i_set=gameManager.CheckIngredientSet();
             
             if (gameManager.CheckIngredientSet())
 
@@ -138,6 +138,15 @@ public class GroundSpawner : MonoBehaviour
                     temp.GetComponent<GroundTile>().SpawnStation();
                 }
             }
+            else
+            {
+                stations = GameObject.FindGameObjectsWithTag("CookingStation");
+                if (stations.Length < 1)
+                {
+                    temp.GetComponent<GroundTile>().SpawnStation();
+                }
+            }
+             
         }
         if (spawnHammer && GameTracker.level != 1)
         {

--- a/prototype/Assets/Scripts/SanctumEntrance.cs
+++ b/prototype/Assets/Scripts/SanctumEntrance.cs
@@ -7,6 +7,8 @@ public class SanctumEntrance : MonoBehaviour
 {
     
     PlayerMovement playerMovement;
+    public GameManager gameManager;
+
     public Mesh[] mesh;
     public Material[] mat;
     public int ingredientID;
@@ -98,10 +100,11 @@ public class SanctumEntrance : MonoBehaviour
 
         Destroy(gameObject);
 
-        if (GameTracker.coins >= GameTracker.ingredientsList[ingredientList[ingredientID]].cost)
+       // if (GameTracker.coins >= GameTracker.ingredientsList[ingredientList[ingredientID]].cost)
+         if (GameTracker.ingred1 >= 1 && GameTracker.ingred2 >= 1 && GameTracker.ingred3 >= 1)
         {
 
-            GameTracker.coins -= GameTracker.ingredientsList[ingredientList[ingredientID]].cost;
+            //GameTracker.coins -= GameTracker.ingredientsList[ingredientList[ingredientID]].cost;
             SceneManager.LoadScene("Sanctum");
 
         }

--- a/prototype/Assets/Scripts/SanctumQuiz.cs
+++ b/prototype/Assets/Scripts/SanctumQuiz.cs
@@ -151,15 +151,16 @@ public class SanctumQuiz : MonoBehaviour
             if (GameTracker.ingred1 >= 1 && GameTracker.ingred2 >= 1 && GameTracker.ingred3 >= 1)
             {
                 //dish = dish + Math.Min(GameTracker.ingred1, Math.Min(GameTracker.ingred2, GameTracker.ingred3));
-                GameTracker.dish = GameTracker.dish + Math.Min(GameTracker.ingred1, Math.Min(GameTracker.ingred2, GameTracker.ingred3));
+                //GameTracker.dish = GameTracker.dish + Math.Min(GameTracker.ingred1, Math.Min(GameTracker.ingred2, GameTracker.ingred3));
+                GameTracker.dish = GameTracker.dish + 1;
 
-                int minCount = Math.Min(GameTracker.ingred1, Math.Min(GameTracker.ingred2, GameTracker.ingred3));
+               // int minCount = Math.Min(GameTracker.ingred1, Math.Min(GameTracker.ingred2, GameTracker.ingred3));
 
-                GameTracker.coins += (GameTracker.recipe.earning * Math.Min(GameTracker.ingred1, Math.Min(GameTracker.ingred2, GameTracker.ingred3)));
+                //GameTracker.coins += (GameTracker.recipe.earning * Math.Min(GameTracker.ingred1, Math.Min(GameTracker.ingred2, GameTracker.ingred3)));
 
-                GameTracker.ingred1 = Math.Max(0, GameTracker.ingred1 - minCount);
-                GameTracker.ingred2 = Math.Max(0, GameTracker.ingred2 - minCount);
-                GameTracker.ingred3 = Math.Max(0, GameTracker.ingred3 - minCount);
+                GameTracker.ingred1 = Math.Max(0, GameTracker.ingred1 - 1);
+                GameTracker.ingred2 = Math.Max(0, GameTracker.ingred2 - 1);
+                GameTracker.ingred3 = Math.Max(0, GameTracker.ingred3 - 1);
 
             }
             // GameTracker.LoadScenes();


### PR DESCRIPTION
1. Fixed hint counter, now it goes to 0 (TODO# 1.C)
2. Changed cooking station logic (spawn cooking station frequently, but player can only get into the sanctum only when they have enough ingredient. (TODO# 11.1 and 11.2)
3. changed the Game logic (TODO# 14.A and 14.B) Any ingredient can be collected (remove logic that prevents ingredients when not enough coins) If they answer correctly, increment dish by 1 only. @Guinguin0416 @SanBlig please review.