### PR TITLE
Change message after wrong answer in sanctum

### DIFF
--- a/prototype/Assets/Scripts/GameManager.cs
+++ b/prototype/Assets/Scripts/GameManager.cs
@@ -488,8 +488,8 @@ public class GameManager : MonoBehaviour
 
         if (SanctumQuiz.notCollected == true && notCollectedIngredienttimeDisplay >= 0)
         {
-            notCollectedIngredient.color = Color.red;
-            notCollectedIngredient.text = "No Reward Collected!";
+            notCollectedIngredient.color = Color.black;
+            notCollectedIngredient.text = "Did not cook dish!";
             notCollectedIngredienttimeDisplay -= (Time.deltaTime / 2);
 
         }


### PR DESCRIPTION
Change message from "No Reward Collected!" to "Did not cook dish!" after wrong answer in sanctum and change color from red to black to improve visibility.